### PR TITLE
After installation you have to restart apache

### DIFF
--- a/docroot/index-perf.php
+++ b/docroot/index-perf.php
@@ -52,6 +52,9 @@ register_shutdown_function(function() use ($time_start, $profiler_namespace, $be
     $profiler_url = sprintf($base_url . '/xhprof-kit/xhprof/xhprof_html/index.php?source=%s&url=%s&run=%s&extra=%s', $profiler_namespace, urlencode($benchmark_url), $run_id, $profiler_extra);
     echo $run_id . '|' . $profiler_namespace . '|' . $profiler_extra . '|' . '<a href="'. $profiler_url .'" target="_blank">Profiler output</a>' . "\n";
   }
+  else {
+    echo "Extension not loaded, maybe restart apache after the installation.";
+  }
 
 });
 


### PR DESCRIPTION
Yeah its a silly mistake, but I just forgot to restart
apache after installation a fresh xhprof instance.

Looking at index-perf.php itself though works,
so maybe a small reminder would be great.